### PR TITLE
Remove spurious "x is not a target" exceptions when refresh called on a target offscreen

### DIFF
--- a/background-check.js
+++ b/background-check.js
@@ -625,9 +625,12 @@
     for (var t = 0; t < total; t++) {
       target = get('targets')[t];
 
+      if (mode === 'targets' && (!checkTarget || checkTarget === target)) {
+        found = true;
+      }
+
       if (isInside(target, viewport)) {
         if (mode === 'targets' && (!checkTarget || checkTarget === target)) {
-          found = true;
           calculatePixelBrightness(target);
         } else if (mode === 'image' && isInside(target, checkTarget)) {
           calculatePixelBrightness(target);


### PR DESCRIPTION
Currently if you try to .refresh() an element off screen, found will not get set to true, and check throws the "x is not a target" exception. I don't think the caller should have to check if the element is on screen, so this just suppresses the error in this case.
